### PR TITLE
add structure to install section; add docker-compose instructions

### DIFF
--- a/docs/install/docker-compose.md
+++ b/docs/install/docker-compose.md
@@ -69,11 +69,13 @@ Configuration is done through two files:
 * projects.json
 * setup.cfg
 
-Docker-Compoes is by default configured to look for these files in the 'default-grimoirelab-settings' folder. 
+Docker-Compose is by default configured to look for these files in the 'default-grimoirelab-settings' folder. 
 
 ```bash
 $ cd ../default-grimoirelab-settings
 ```
+
+The configuration is the same for all ways of installing GrimoireLab and thus explained in [the general installation page](./..).
 
 ## Error Handling
 

--- a/docs/install/docker-compose.md
+++ b/docs/install/docker-compose.md
@@ -1,0 +1,91 @@
+---
+layout: default
+title: Docker Compose Install
+nav_order: 2
+parent: Install
+---
+
+
+# Instal GrimoireLab using Docker Compose
+
+Use this method for installing GrimoireLab if you want to:
+
+* have separate containers for databases
+* insight to the different components required to run GrimoireLab
+
+
+## Prerequisites
+
+Make sure you have the following applications and services available:
+
+- [Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [Docker](https://docs.docker.com/v17.09/engine/installation/)
+- [Docker Compose](https://docs.docker.com/compose/install/)
+- [Docker Machine](https://docs.docker.com/machine/install-machine/)
+
+You do this by running the following commands:
+
+```bash
+$ git --version
+$ docker --version
+$ docker-compose --version
+$ docker-machine --version
+```
+
+Resources requirements depend on the number of projects and their size:
+- Plan for a minimum of 100GB of storage, 2 CPUs, and 8 GB of RAM for a analyzing a small project.
+
+
+## Get Docker Compose Instructions
+
+The Docker Compose instructions `docker-compose.yml` are located in the GrimoireLab repository. Clone it to a local folder of your choice.
+
+```bash
+$ git clone https://github.com/chaoss/grimoirelab
+$ cd grimoirelab/docker-compose
+```
+
+
+## Start GrimoireLab
+
+Before starting GrimoireLab the first time, make sure to [set `vm.max_map_count` to at least `262144`](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_set_vm_max_map_count_to_at_least_262144) for elasticsearch.
+
+By default, GrimoireLab is ready to be started. 
+
+```bash
+$ docker-compose up -d
+```
+Once your containers are all started successfully, go to http://localhost:5601 
+
+Manage contributors profile information with HatStall at http://localhost:8000 
+To get access:
+* User: admin
+* Pass: admin
+
+## Configure GrimoireLab
+
+Configuration is done through two files:
+
+* projects.json
+* setup.cfg
+
+Docker-Compoes is by default configured to look for these files in the 'default-grimoirelab-settings' folder. 
+
+```bash
+$ cd ../default-grimoirelab-settings
+```
+
+## Error Handling
+
+If you experience an error, run `docker-compose` up without the `-d` flag. That will output all messages and give insight to problems. 
+
+
+### Unable to connect to Elasticsearch on first start?
+
+By default, Elasticsearch will not work. This is a known problem: you need to [set `vm.max_map_count' to at least `262144'](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_set_vm_max_map_count_to_at_least_262144). See the [elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html#_set_vm_max_map_count_to_at_least_262144) for how to do it on Linux, Mac, or Windows.
+
+
+### Port already in use?
+
+If an error reads something like “Error starting proxy: listen tcp 0.0.0.0:3306: bind: address already in use”, then you already have a program listening on a port, in this case port 3306 which would be the case if you are running an AMP with MySQL. 
+To resolve this issue, stop the service that is already using a port GrimoireLab needs.

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Docker Install
+nav_order: 2
+parent: Install
+---

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -27,7 +27,7 @@ GrimoireLab needs to know what projects to collect data from.
 The default [projects.json](https://github.com/chaoss/grimoirelab/blob/master/default-grimoirelab-settings/projects.json) file is configured to collect metrics about the GrimoireLab git repository. 
 
 To start collecting data about the projects that matter to you, you need to define projects and data endpoints in the project.json file.
-The [GrimoireLab tutorial section on the projects file](https://chaoss.github.io/grimoirelab-tutorial/sirmordred/projects.html) explains how the file needs to be built.
+The [GrimoireLab tutorial section on the projects file](https://github.com/chaoss/grimoirelab-sirmordred#projectsjson) explains how the file needs to be built.
 
 ### Provide API keys and other configurations
 

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -8,13 +8,35 @@ has_toc: false
 
 # Install GrimoireLab
 
-* pip
-* docker
-* docker-compose
+GrimoireLab offers three options for installation:
 
-## Define analysis scope:
+* [Docker Compose](./docker-compose)
+  - Use `docker-compose` if you want separate containers for the database.
+* [Docker](./docker)
+  - Use `docker` if you want to work with one self-contained container that includes everything.
+* [PIP](./pip)
+  - Use `pip` if you want to use GrimoireLab components individually.
 
-### Intro to projects.json
-### Intro to setup.cfg
+Regardless of which way you install GrimoireLab, you will need to configure it as described below.
+
+## Define analysis scope
+
+### Tell GrimoireLab what projects to collect data from
+
+GrimoireLab needs to know what projects to collect data from. 
+The default [projects.json](https://github.com/chaoss/grimoirelab/blob/master/default-grimoirelab-settings/projects.json) file is configured to collect metrics about the GrimoireLab git repository. 
+
+To start collecting data about the projects that matter to you, you need to define projects and data endpoints in the project.json file.
+The [GrimoireLab tutorial section on the projects file](https://chaoss.github.io/grimoirelab-tutorial/sirmordred/projects.html) explains how the file needs to be built.
+
+### Provide API keys and other configurations
+
+In addition to defining projects and their data endpoints, specific data endpoints need to be activated in GrimoireLab.
+The default [setup.cfg](https://github.com/chaoss/grimoirelab/blob/master/default-grimoirelab-settings/setup.cfg) has only `git` enabled.
+
+Enabling additional data endpoints, such as GitHub issues and pull requests, involves (1) uncommenting relevant sections in the setup.cfg and (2) providing API keys.
+
 
 ## Deploy and run GrimoireLab
+
+TBD

--- a/docs/install/pip.md
+++ b/docs/install/pip.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: pip Install
+nav_order: 2
+parent: Install
+---


### PR DESCRIPTION
I think we should separate out the three ways to install GrimoireLab and have separate pages for each but have one central page for the projects.json and setup.cfg.

This pr adds pages for Docker, Docker Compose, and PIP. 

This pr adds content for the main install page and the Docker Compose install method.

PIP and Docker need to be done later.