### PR TITLE
[install] Complete pip section

### DIFF
--- a/docs/install/pip.md
+++ b/docs/install/pip.md
@@ -29,6 +29,9 @@ $ sudo apt-get install python3-dev
 $ sudo apt-get install build-essential
 ```
 
+In order to run GrimoireLab, you need to have Elasticsearch, Kibiter and MySQL running in your machine. For the
+sake of simplicity, we assume that they run in localhost with no authentication needed.
+
 **Hardware**: Resources requirements depend on the number of projects and their size:
 - Plan for a minimum of 100GB of storage, 2 CPUs, and 8 GB of RAM for analyzing a small/medium size project.
 
@@ -91,9 +94,6 @@ Once installed, check that everything is as it should be:
 
 
 ### Run GrimoireLab
-
-In order to run GrimoireLab, you need to have Elasticsearch, Kibiter and MySQL running in your machine. For the
-sake of simplicity, we assume that they run in localhost with no authentication needed.
 
 GrimoireLab can be launched with the following command:
 ```console

--- a/docs/install/pip.md
+++ b/docs/install/pip.md
@@ -19,7 +19,8 @@ Use `pip` for installing GrimoireLab if you want to:
 
 **Software**
 
-[Python 3](https://www.python.org/downloads/) is required.
+[Python 3](https://www.python.org/downloads/) is required. Currently, GrimoireLab is developed using Python 3.5 and 3.6, thus
+any of these versions should be safe to grant GrimoireLab to run smoothly.
 
 Some of GrimoireLab dependencies need non-Python packages as pre-requisites to be installed. In Debian-derived systems (such as Ubuntu), that can be done by installing the python3-dev package:
 
@@ -29,7 +30,7 @@ $ sudo apt-get install build-essential
 ```
 
 **Hardware**: Resources requirements depend on the number of projects and their size:
-- Plan for a minimum of 100GB of storage, 2 CPUs, and 8 GB of RAM for a analyzing a small project.
+- Plan for a minimum of 100GB of storage, 2 CPUs, and 8 GB of RAM for analyzing a small/medium size project.
 
 
 ## Use a Python virtual environment
@@ -69,17 +70,17 @@ This step will increase the chances that you have no troubles later.
 Depending on what you have installed in your system, it may be convenient to install some Python tools in it, and to upgrade some others. We recommend that you type, in your activated virtual environment:
 
 ```console
-(gl) $ pip3 install --upgrade pip
-(gl) $ pip3 install --upgrade setuptools
-(gl) $ pip3 install --upgrade wheel 
+(gl) $ pip install --upgrade pip
+(gl) $ pip install --upgrade setuptools
+(gl) $ pip install --upgrade wheel
 ```
 
 ### Install all GrimoireLab tools at once
 
-Use `pip3` to install the `grimoirelab` package, that pulls all the other GrimoireLab tools as dependencies:
+Use `pip` to install the `grimoirelab` package, that pulls all the other GrimoireLab tools as dependencies:
 
 ```console
-(gl) $ pip3 install grimoirelab
+(gl) $ pip install grimoirelab
 ```
 
 Once installed, check that everything is as it should be:
@@ -91,9 +92,37 @@ Once installed, check that everything is as it should be:
 
 ### Run GrimoireLab
 
-TBD
+In order to run GrimoireLab, you need to have Elasticsearch, Kibiter and MySQL running in your machine. For the
+sake of simplicity, we assume that they run in localhost with no authentication needed.
 
+GrimoireLab can be launched with the following command:
+```console
+(gl) $ sirmordred -c <path to setup.cfg>
+```
+
+The GrimoireLab repository contains a set of default settings that can be used to execute GrimoireLab. You
+can follow the steps below to get them:
+
+1. Clone the github.com/chaoss/grimoirelab project repository
+```console
+$ git clone https://github.com/chaoss/grimoirelab
+```
+
+2. Go to the settings folder
+```console
+$ cd grimoirelab/default-grimoirelab-settings
+```
+
+3. Run the following command
+```console
+$ sirmordred -c setup-pip.cfg
+```
 
 ### Configure GrimoireLab
 
-TBD
+Configuration is done through two files:
+
+* projects.json
+* setup.cfg
+
+They are described in the [Sirmordred repository](https://github.com/chaoss/grimoirelab-sirmordred/blob/master/README.md)


### PR DESCRIPTION
This PR completes the PIP section by adding the info needed to run and configure GrimoireLab. A PR to GrimoireLab repo has been submitted to include the menu.yml file and the setup.cfg for a local execution within the default-grimoirelab-settings folder.

Related to:
- https://github.com/jsmanrique/grimoirelab-user-guide/pull/17#issue-353341667
- https://github.com/chaoss/grimoirelab/pull/256